### PR TITLE
Add locationBonus for capitals

### DIFF
--- a/packages/dominus-battles/calculator/armies.js
+++ b/packages/dominus-battles/calculator/armies.js
@@ -302,6 +302,11 @@ BattleArmy.prototype.updateLocationBonus = function() {
     self.villageDefenseBonus = true
   }
 
+  if (self.unitType == 'capital') {
+    self.locationBonus = self.basePower.total * (_s.capitals.battleBonus - 1);
+    self.capitalDefenseBonus = true
+  }
+
   if (self.unitType == 'army') {
     if (self.isOnAllyCastle) {
       self.locationBonus = self.basePower.total * (_s.castles.ally_defense_bonus - 1);


### PR DESCRIPTION
There were if blocks for castle and village locationBonuses but not for capitals.

I noticed that the battle calculator in the UI was not showing a location bonus for the capital garrison. Also, I saw that a battle report of a player taking a capital did not include any location bonus for the capital garrison.

If this is accepted, players should be informed that 30 catapults will no longer be sufficient to take a capital with its whole/initial garrison.
