### PR TITLE
Update the help tree Vassals, Lords and Kings link

### DIFF
--- a/packages/dominus-help/client/help_tree.html
+++ b/packages/dominus-help/client/help_tree.html
@@ -27,7 +27,7 @@ You cannot attack anyone below you in the tree.  These will have a yellow or ora
 
 You can attack the castle of people above you in the tree but you cannot attack their armies or villages.  These will have a blue or purple square or flag.
 
-Watch [this tutorial](https:// youtu.be/5CNR4X9bOlM) for more info.
+Watch [this tutorial](https://youtu.be/5CNR4X9bOlM) for more info.
 
 {{/markdown}}
       </div>


### PR DESCRIPTION
The link had a space in it that translated to https://%20youtu.be/5CNR4X9bOlM instead of https://youtu.be/5CNR4X9bOlM.