### PR TITLE
Fix false "no longer dominus" alerts from transient no-king state

### DIFF
--- a/packages/dominus-manager/server/checkForDominus.js
+++ b/packages/dominus-manager/server/checkForDominus.js
@@ -15,6 +15,22 @@ dManager.checkForDominus = function(gameId) {
 		return;
 	}
 
+	// Guard against a transient "no king" state.
+	// relation_finder (the relationship rebuild) sets is_king:false for every
+	// player in a tree and only restores is_king:true for the king at the end of
+	// the same non-atomic bulk op. If checkForDominus reads during that window it
+	// finds no king, wrongly clears is_dominus, and fires a false
+	// "no longer dominus" alert (re-announcing "new dominus" on the next pass).
+	// In any consistent state with >=2 castle-holders the hierarchy is a forest
+	// whose roots are kings, so there is always at least one is_king:true player.
+	// Zero kings therefore means we are reading an inconsistent/transient state --
+	// bail out without touching is_dominus or alerting. A real dethroning always
+	// leaves at least one king, so this does not suppress legitimate updates.
+	let numKings = Players.find({gameId:gameId, is_king:true, castle_id: {$exists: true, $ne:null}}).count();
+	if (numKings == 0) {
+		return;
+	}
+
 	let dominus = Players.findOne({gameId:gameId, is_dominus:true}, {fields: {gameId:1}});
 	let is_still_dominus = false;
 

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -451,12 +451,17 @@ if (Meteor.isServer) {
 
       // --- Nightly Rebuild ---
 
-      run('stale is_king:false during rebuild causes false noLongerDominus alert', function() {
-        // This test proves the mechanism of the nightly bug:
-        // relation_finder.traverse_down sets is_king:false for all players,
-        // then reached_top restores is_king:true for the king. If the bulk op
-        // hasn't committed when checkForDominus runs, it sees no kings and
-        // fires a false "no longer dominus" alert.
+      run('no-king rebuild window does not clear dominus or fire false alert', function() {
+        // Regression test for the false "no longer dominus" alert race (fix
+        // branch fix/dominus-no-king-race). relation_finder transiently sets
+        // is_king:false for every player mid-rebuild; if checkForDominus reads
+        // during that window it used to see no king, clear is_dominus, and fire
+        // a false alert_noLongerDominus (then re-announce "new dominus" next
+        // pass). The fix bails out when zero kings exist -- an impossible state
+        // whenever >=2 players hold castles, so it can only be a transient read.
+        // This test forces the zero-king window and asserts the dominus is
+        // preserved and no alert fires. On the pre-fix code this FAILS (dominus
+        // cleared + alert fired), which is exactly what it must catch.
         Games.remove({});
         Players.remove({});
         Alerts.remove({});
@@ -474,14 +479,14 @@ if (Meteor.isServer) {
         Alerts.remove({gameId: game._id});
         GlobalAlerts.remove({gameId: game._id});
 
-        // simulate the intermediate state: relation_finder has set is_king:false
-        // for everyone but the bulk op restoring is_king:true hasn't committed yet
+        // simulate the mid-rebuild window: is_king:false committed for everyone
+        // (relation_finder set it and hasn't restored is_king:true yet)
         Players.update({gameId: game._id}, {$set: {is_king: false}}, {multi: true});
         dManager.checkForDominus(game._id);
 
-        // proves: stale is_king:false causes a false alert
-        let falseAlerts = Alerts.find({gameId: game._id, type: 'alert_noLongerDominus'}).count();
-        _testAssert(falseAlerts > 0, 'stale is_king:false causes false noLongerDominus alert');
+        // fix: a transient no-king read is ignored -> dominus preserved, no alert
+        _testAssert(Players.findOne(p1, {fields:{is_dominus:1}}).is_dominus === true, 'dominus preserved during no-king window');
+        _testEqual(Alerts.find({gameId: game._id, type: 'alert_noLongerDominus'}).count(), 0, 'no false noLongerDominus alert');
 
         Alerts.remove({gameId: game._id});
         GlobalAlerts.remove({gameId: game._id});


### PR DESCRIPTION
checkForDominus decides the dominus from the is_king flag, but relation_finder rebuilds relationships in one non-atomic bulk op that sets is_king:false for every player and only restores is_king:true for the king at the end. During that committed window there are zero kings. A checkForDominus that reads then finds no king, wrongly clears is_dominus, and fires a false alert_noLongerDominus -- then re-announces "new dominus" on the next pass (the flag/alert flapping players report).

The prior fix (72c3119) made the nightly job's own checkForDominus wait for the rebuild, but the non-atomic window still races any other checkForDominus caller (e.g. the synchronous player-deletion path) and there is no guard in checkForDominus itself.

In any consistent state with >=2 castle-holders the hierarchy is a forest whose roots are kings, so at least one is_king:true player always exists. Zero kings therefore means a transient/inconsistent read: bail out before clearing is_dominus or alerting. A real dethroning always leaves at least one king, so legitimate updates are unaffected.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg