### PR TITLE
Don't strand a game when the dominus countdown has no resolvable winner

### DIFF
--- a/packages/dominus-manager/server/gameEndJob.js
+++ b/packages/dominus-manager/server/gameEndJob.js
@@ -73,7 +73,16 @@ var checkForGameEnd = function() {
       Queues.add('updateOverallPlayerRankings', {}, {attempts:10, backoff:{type:'fixed', delay:15000}, delay:0, timeout:1000*60*10}, false);
 
     } else {
-      console.error('game ended but no winning player found', game)
+      // No resolvable winner: the recorded dominus (is_dominus, and the
+      // fallback game.lastDominusPlayerId) no longer exists -- e.g. that player
+      // deleted their account while the countdown was running. Committing
+      // hasEnded:true above without ever setting a closeDate would strand the
+      // game forever (checkForGameClose requires closeDate <= now, so it never
+      // runs) with no winner declared and players never sent to game-over.
+      // Instead, revert hasEnded and cancel the stale countdown so play can
+      // continue; a future real dominus will restart the countdown.
+      console.error('game endDate reached but no winning player found; clearing stale countdown', game._id)
+      Games.update(game._id, {$set: {hasEnded:false, endDate:null, lastDominusPlayerId:null}});
     }
   }
 };


### PR DESCRIPTION
When someone becomes dominus, game.endDate starts a countdown and the winner is recorded via game.lastDominusPlayerId. Nothing clears that countdown if the dominus is removed from the game, and any player can delete their game account with no guard (settingsMethods.deleteGameAccount -> gameServerFunctions.deleteGameAccount removes the Players doc and only clears is_dominus, never the Games doc).

So if the dominus deletes their account mid-countdown, checkForGameEnd later commits hasEnded:true (line 28) but then finds no winner: is_dominus matches nobody and Players.findOne(lastDominusPlayerId) is null (deleted). The old code just console.error'd, leaving the game hasEnded:true with no closeDate -- and checkForGameClose requires closeDate <= now, so the game never closes, never declares a winner, and its remaining players are never sent to the game-over screen.

Revert hasEnded and clear the stale countdown (endDate/lastDominusPlayerId) instead, so play continues and a future real dominus restarts it. This also covers any other winner-less end, not just account deletion.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg