### PR TITLE
Promote vassals to kings when a deleted player's lord is missing

### DIFF
--- a/packages/dominus-game/server/gameServerFunctions.js
+++ b/packages/dominus-game/server/gameServerFunctions.js
@@ -64,6 +64,21 @@ dGame.deleteGameAccount = function(playerId) {
 
 			// remove from lord
 			dInit.remove_lord_and_vassal(lord._id, player._id);
+		} else {
+			// player.lord points at a lord that no longer exists (e.g. that lord was
+			// deleted first, or a pre-existing dangling pointer). Without this branch
+			// the player's vassals are left orphaned with a dangling lord pointer and
+			// is_king:false -- invisible to generateTree and the nightly rebuild, yet
+			// still counted by checkForDominus, which permanently blocks any dominus
+			// (unwinnable game). Promote them to kings, same as the no-lord branch.
+			if (player.vassals) {
+				player.vassals.forEach(function(vassal_id) {
+					var vassal = Players.findOne(vassal_id, {fields:{_id:1}});
+					if (vassal) {
+						dInit.remove_lord_and_vassal(player._id, vassal._id);
+					}
+				});
+			}
 		}
 	} else {
 		// make vassals kings

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -533,6 +533,49 @@ if (Meteor.isServer) {
       });
 
 
+      // --- Account deletion: orphan subtree ---
+
+      run('deleting a lord with a missing super-lord promotes its vassals to kings', function() {
+        // Regression test for fix/dominus-orphan-subtree. When a deleted
+        // player's `lord` points at a doc that no longer exists,
+        // deleteGameAccount used to skip vassal reparenting (the if(lord) block
+        // had no else), orphaning the subtree: vassals left is_king:false with a
+        // dangling lord, invisible to the tree/rebuild but still counted by
+        // checkForDominus -> unwinnable game. The fix promotes them to kings.
+        Games.remove({}); Players.remove({});
+        let game = _createTestGame({hasStarted: true});
+        let uP = _createTestUser();
+        let uV = _createTestUser();
+
+        // P points at a missing lord and has one vassal V.
+        let pId = Players.insert({gameId: game._id, userId: uP._id, username: uP.username,
+          is_king: false, lord: 'ghost-missing-lord', king: 'ghost-missing-lord',
+          vassals: [], allies_above: ['ghost-missing-lord'], allies_below: [], team: [], castle_id: 'cP'});
+        let vId = Players.insert({gameId: game._id, userId: uV._id, username: uV.username,
+          is_king: false, lord: pId, king: 'ghost-missing-lord',
+          vassals: [], allies_above: [pId, 'ghost-missing-lord'], allies_below: [], team: [], castle_id: 'cV'});
+        Players.update(pId, {$set: {vassals: [vId], allies_below: [vId]}});
+
+        dGame.deleteGameAccount(pId);
+
+        let v = Players.findOne(vId, {fields: {is_king: 1, lord: 1}});
+        _testAssert(!!v, 'vassal still exists');
+        _testAssert(v.is_king === true, 'orphaned vassal promoted to king');
+        _testAssert(v.lord === null, 'orphaned vassal has no dangling lord');
+        _testAssert(!Players.findOne(pId), 'deleted player removed');
+
+        Alerts.remove({gameId: game._id});
+        GlobalAlerts.remove({gameId: game._id});
+        Armies.remove({gameId: game._id});
+        Villages.remove({gameId: game._id});
+        Markers.remove({gameId: game._id});
+        _testCleanup(game._id);
+        Games.remove({hasStarted: false, hasClosed: false});
+        _testCleanupUser(uP._id);
+        _testCleanupUser(uV._id);
+      });
+
+
       // --- Results ---
       console.log('\n========================================');
       console.log('  Game Creation Tests: ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
deleteGameAccount's tree-fix has a `if (player.lord) { lord = findOne(...); if (lord) { reparent vassals } }` block with no else. If player.lord is a truthy id but that lord document no longer exists (e.g. the lord was deleted first, or a pre-existing dangling pointer), the vassal-handling is skipped entirely and the player is then removed -- leaving every direct vassal with lord = <deleted id> and is_king:false.

Those orphans are not roots (generateTree finds roots via lord:null so they vanish from the tree) and are unreachable by the nightly rebuild (which seeds from is_king:true and walks down), yet they still hold a castle, so checkForDominus counts them in every king's nonVassals forever -- no one can ever become dominus and the game can never be won or end. It also cascades: each orphan now has a dangling lord.

Mirror the no-lord branch: when the lord is missing, promote the player's vassals to kings instead of orphaning them.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg