### PR TITLE
Resolve the lord's king (not the vassal's) in create_lord_and_vassal

### DIFF
--- a/packages/dominus-init/server/relationships.js
+++ b/packages/dominus-init/server/relationships.js
@@ -264,7 +264,14 @@ var create_lord_and_vassal = function(lord_id, vassal_id) {
 	} else if (lord.king){
 		newKing = lord.king;
 	} else {
-		newKing = getKingOf(vassal_id);
+		// resolve the LORD's king (see comment above: "king of lord").
+		// getKingOf(vassal_id) is wrong here: this runs before the bulk that sets
+		// vassal.lord = lord_id has executed, and the precondition requires
+		// vassal.lord to be null, so getKingOf(vassal_id) returns vassal_id itself.
+		// That would point the whole vassal subtree's king at a mid-tree node,
+		// making checkForDominus count them as non-vassals and blocking a
+		// legitimate dominus until the nightly rebuild.
+		newKing = getKingOf(lord_id);
 	}
 
 	if (!newKing) {


### PR DESCRIPTION
The king-fallback branch called getKingOf(vassal_id), but the comment two lines above says to set the subtree's king to the "king of lord". Because this runs before the bulk that sets vassal.lord = lord_id executes -- and the precondition requires vassal.lord to be null -- getKingOf(vassal_id) walks an empty lord chain and returns vassal_id itself.

So newKing became the vassal, and setKingIds (the whole vassal subtree + vassal + lord) all got king = vassal, a mid-tree node. checkForDominus (king:{$ne:king._id}) then counts those players as non-vassals, so a legitimate dominus is blocked until the nightly rebuild heals the tree.

Use getKingOf(lord_id): the lord's lord chain is already committed, so it correctly resolves the true root.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg