### PR TITLE
Fix dominus army being both ally and enemy in battle math

### DIFF
--- a/packages/dominus-battles/calculator/armies.js
+++ b/packages/dominus-battles/calculator/armies.js
@@ -197,6 +197,16 @@ BattleArmy.prototype.isAlly = function(otherArmy) {
     return this.playerId == otherArmy.playerId;
   }
 
+  // A dominus's army (and its opponent) is never an ally in army-vs-army.
+  // isEnemy has a matching override that forces these pairings to fight (a
+  // dominus can attack anyone's armies). Without this, a dominus and their own
+  // vassal on the same hex would be classified as BOTH ally and enemy, so the
+  // vassal's power is double-counted on the dominus's side while they also
+  // fight -- corrupting battle resolution. Mirror the isEnemy override here.
+  if ((this.is_dominus || otherArmy.is_dominus) && this.unitType == 'army' && otherArmy.unitType == 'army') {
+    return false;
+  }
+
   var player = {_id:this.playerId, team:this.team, lord:this.lord, allies_above:this.allies_above, allies_below:this.allies_below, king:this.king, vassals:this.vassals};
   var otherPlayerId = otherArmy.playerId;
   var relation = dInit.getPlayersRelationship(player, otherPlayerId);

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -533,6 +533,37 @@ if (Meteor.isServer) {
       });
 
 
+      // --- Battle calculator: dominus ally/enemy ---
+
+      run('dominus army is enemy-not-ally of its own vassal', function() {
+        // Regression test for fix/dominus-attack-ally-enemy. isEnemy has a
+        // dominus override (a dominus can attack anyone's armies); isAlly must
+        // have a matching override so a dominus and its own vassal are never
+        // BOTH enemy and ally (which double-counts the vassal's power in the
+        // battle round). Pure calculator test -- no DB.
+        //
+        // D is dominus; V is D's direct vassal. Relation from D's view is
+        // 'direct_vassal' (V in D.team, D.allies_below, D.vassals).
+        var D = new BattleArmy();
+        D.unitType = 'army'; D.playerId = 'D'; D.is_dominus = true;
+        D.king = 'D'; D.lord = null; D.team = ['V']; D.allies_above = [];
+        D.allies_below = ['V']; D.vassals = ['V'];
+
+        var V = new BattleArmy();
+        V.unitType = 'army'; V.playerId = 'V'; V.is_dominus = false;
+        V.king = 'D'; V.lord = 'D'; V.team = ['D']; V.allies_above = ['D'];
+        V.allies_below = []; V.vassals = [];
+
+        _testAssert(D.isEnemy(V) === true, 'dominus is enemy of its vassal (can attack any army)');
+        _testAssert(D.isAlly(V) === false, 'dominus is NOT also an ally of its vassal');
+
+        // no regression: with D not a dominus, its vassal is a normal ally.
+        D.is_dominus = false;
+        _testAssert(D.isAlly(V) === true, 'non-dominus lord is an ally of its vassal');
+        _testAssert(D.isEnemy(V) === false, 'non-dominus lord is not an enemy of its vassal');
+      });
+
+
       // --- Results ---
       console.log('\n========================================');
       console.log('  Game Creation Tests: ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
isEnemy has an is_dominus override making any army-vs-army pairing an enemy when either side is dominus (a dominus can attack anyone's armies). isAlly had no matching override, so a dominus and their own vassal on the same hex satisfied BOTH isEnemy and isAlly. getAllies/getEnemies then put the vassal in both sets, double-counting the vassal's power on the dominus's side while also fighting them -- corrupting the round's power comparison and win/loss.

Add the symmetric override to isAlly so a dominus-involved army-vs-army pairing is never also counted as an ally. This preserves the intended rule (dominus attacks everyone's armies) and just makes ally/enemy classification consistent.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg