### PR TITLE
Require admin for queue pause/resume/clear methods

### DIFF
--- a/packages/dominus-queue/queueMethods.js
+++ b/packages/dominus-queue/queueMethods.js
@@ -1,5 +1,16 @@
 Meteor.methods({
   pauseJobQueue: function() {
+    // allow trusted server-side calls (this.connection === null, e.g. the
+    // relationship-rebuild job that pauses the queue while it runs); block
+    // client (DDP) calls from non-admins -- otherwise any player could freeze
+    // battles/income/movement for every game on the server.
+    if (this.connection) {
+      var user = Meteor.users.findOne(this.userId, {fields:{admin:1}});
+      if (!user || !user.admin) {
+        throw new Meteor.Error('not-authorized', 'Must be admin.');
+      }
+    }
+
     let Future = Npm.require('fibers/future');
 
     Settings.upsert({}, {$set: {isPaused:true}});
@@ -17,6 +28,14 @@ Meteor.methods({
 
 
   resumeJobQueue: function() {
+    // allow trusted server-side calls; block non-admin client calls (see pauseJobQueue).
+    if (this.connection) {
+      var user = Meteor.users.findOne(this.userId, {fields:{admin:1}});
+      if (!user || !user.admin) {
+        throw new Meteor.Error('not-authorized', 'Must be admin.');
+      }
+    }
+
     let Future = Npm.require('fibers/future');
 
     Settings.upsert({}, {$set: {isPaused:false}});
@@ -34,6 +53,16 @@ Meteor.methods({
 
 
   clearUniqueIdsForJob: function(jobName) {
+    // allow trusted server-side calls; block non-admin client calls (see pauseJobQueue).
+    if (this.connection) {
+      var user = Meteor.users.findOne(this.userId, {fields:{admin:1}});
+      if (!user || !user.admin) {
+        throw new Meteor.Error('not-authorized', 'Must be admin.');
+      }
+    }
+
+    check(jobName, String);
+
     const queue = Queues[jobName];
 
     if (!queue) {


### PR DESCRIPTION
pauseJobQueue, resumeJobQueue and clearUniqueIdsForJob were plain Meteor.methods with no authorization check (unlike runBullJob right below them). Any connected client could call Meteor.call('pauseJobQueue') and freeze battles, income, movement, etc. for every game on the server, or wipe unique-id dedup to allow duplicate jobs.

These methods are also called internally by trusted server code (the relationship-rebuild job pauses/resumes the queue), where this.userId is absent. Guard on this.connection so server-originated calls still work while client calls require an admin user. Also add the missing check(jobName, String) to clearUniqueIdsForJob.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg