### PR TITLE
Require army ownership in splitArmy

### DIFF
--- a/packages/dominus-armies/both/armyMethods.js
+++ b/packages/dominus-armies/both/armyMethods.js
@@ -192,6 +192,13 @@ Meteor.methods({
     check(armyId, String);
     //this.unblock();
     if (!this.isSimulation) {
+      // only the owner may split an army -- dArmies.split looks up by _id only
+      // and also resets the army's speed/moveTime, so without this any player
+      // could stop and fragment an opponent's army mid-move.
+      var army = Armies.findOne({_id:armyId, gameId:gameId}, {fields: {user_id:1}});
+      if (!army || army.user_id !== this.userId) {
+        throw new Meteor.Error('not-authorized', 'You do not own this army.');
+      }
       var newArmyId = dArmies.split(gameId, armyId, newArmySoldiers);
       if (newArmyId) {
         return newArmyId;

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -533,6 +533,44 @@ if (Meteor.isServer) {
       });
 
 
+      // --- Auth: splitArmy ownership ---
+
+      run('splitArmy rejects a non-owner and leaves the army intact', function() {
+        // Regression test for fix/auth-split-army. splitArmy -> dArmies.split
+        // looked the army up by _id only (and reset its speed/moveTime), so any
+        // player could stop and fragment an enemy army. The fix requires
+        // ownership.
+        Games.remove({}); Players.remove({}); Armies.remove({});
+        let game = _createTestGame({hasStarted: true});
+        let owner = _createTestUser();
+        let attacker = _createTestUser();
+
+        let armyId = Armies.insert({gameId: game._id, user_id: owner._id, playerId: 'pOwner',
+          x: 0, y: 0, footmen: 10, archers: 0, pikemen: 0, cavalry: 0, catapults: 0,
+          speed: 5, moveTime: 123, name: 'testarmy'});
+
+        function callAs(userId, method, args) {
+          var inv = {userId: userId, isSimulation: false, connection: null, unblock: function() {}};
+          return DDP._CurrentInvocation.withValue(inv, function() {
+            return Meteor.server.method_handlers[method].apply(inv, args);
+          });
+        }
+
+        var threw = false;
+        try { callAs(attacker._id, 'splitArmy', [game._id, armyId, {footmen: 5}]); } catch (e) { threw = true; }
+        _testAssert(threw, 'non-owner splitArmy throws');
+        _testEqual(Armies.find({gameId: game._id}).count(), 1, 'no new army was split off');
+        let a = Armies.findOne(armyId);
+        _testEqual(a.footmen, 10, 'original army soldiers untouched');
+        _testEqual(a.speed, 5, 'original army movement not reset by a non-owner');
+
+        Armies.remove({gameId: game._id});
+        _testCleanup(game._id);
+        _testCleanupUser(owner._id);
+        _testCleanupUser(attacker._id);
+      });
+
+
       // --- Results ---
       console.log('\n========================================');
       console.log('  Game Creation Tests: ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
splitArmy(gameId, armyId, newArmySoldiers) called dArmies.split, which looks the army up by _id only (no ownership check) and resets the original army's speed/moveTime to null. Any player could call splitArmy on an enemy armyId to stop that army mid-movement and repeatedly fragment it.

Verify the army belongs to this.userId (server-side) before splitting.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg