### PR TITLE
Require army ownership in joinBuilding

### DIFF
--- a/packages/dominus-armies/both/armyValidatedMethods.js
+++ b/packages/dominus-armies/both/armyValidatedMethods.js
@@ -56,6 +56,18 @@ dArmies.methods.joinBuilding = new ValidatedMethod({
   run({armyId}) {
     // this.unblock();
     if (!this.isSimulation) {
+      // only the owner may join their army into a building -- dArmies.joinBuilding
+      // looks the army up by _id only, so without this a player could force an
+      // enemy army (sitting on its own building hex) to disband into the building.
+      var ownArmy = Armies.findOne({_id:armyId, user_id:this.userId}, {fields: {_id:1}});
+      if (!ownArmy) {
+        var notOwnedError = [{
+          name: 'armies.joinBuilding',
+          type: 'You do not own this army.',
+          details: {armyId}
+        }];
+        throw new ValidationError(notOwnedError);
+      }
       var buildingInfo = dArmies.joinBuilding(armyId);
       if (buildingInfo) {
         return buildingInfo;


### PR DESCRIPTION
The armies.joinBuilding validated method called dArmies.joinBuilding(armyId) with no ownership check (unlike returnToCastle right below it, which scopes on {_id, user_id:this.userId}). dArmies.joinBuilding looks the army up by _id only, so a player could force an enemy army that is sitting on its own castle/village hex to disband into that building.

Verify the army belongs to this.userId before joining.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg