### PR TITLE
Scope change_username to the caller's own player

### DIFF
--- a/packages/dominus-game/both/gameMethods.js
+++ b/packages/dominus-game/both/gameMethods.js
@@ -76,7 +76,12 @@ Meteor.methods({
 		check(username, String);
 		check(playerId, String);
 
-		let player = Players.findOne(playerId, {fields: {is_king:1, username:1, gameId:1}});
+		// scope to the caller's own player -- otherwise passing another player's id
+		// renames that victim's denormalized castle/village/army/chatroom names
+		// (the writes below use player._id) and fires a global name-change alert
+		// attributed to them, even though the authoritative Players write is
+		// already userId-scoped.
+		let player = Players.findOne({_id:playerId, userId:this.userId}, {fields: {is_king:1, username:1, gameId:1}});
 		if (!player) {
 			throw new Meteor.Error('No player found.');
 		}

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -533,6 +533,41 @@ if (Meteor.isServer) {
       });
 
 
+      // --- Auth: change_username scoping ---
+
+      run('change_username cannot rename another player or their castle', function() {
+        // Regression test for fix/auth-change-username. The Players write was
+        // userId-scoped, but the denormalized Castle/Village/Army/Room renames
+        // used playerId only, so passing a victim's playerId renamed their
+        // units. The fix loads the player scoped to the caller and bails.
+        Games.remove({}); Players.remove({}); Castles.remove({});
+        let game = _createTestGame({hasStarted: true});
+        let victim = _createTestUser();
+        let attacker = _createTestUser();
+
+        let victimPid = Players.insert({gameId: game._id, userId: victim._id, username: 'VictimName', is_king: false});
+        let castleId = Castles.insert({gameId: game._id, playerId: victimPid, user_id: victim._id, username: 'VictimName', x: 0, y: 0});
+
+        function callAs(userId, method, args) {
+          var inv = {userId: userId, isSimulation: false, connection: null, unblock: function() {}};
+          return DDP._CurrentInvocation.withValue(inv, function() {
+            return Meteor.server.method_handlers[method].apply(inv, args);
+          });
+        }
+
+        var threw = false;
+        try { callAs(attacker._id, 'change_username', [victimPid, 'Hacked']); } catch (e) { threw = true; }
+        _testAssert(threw, 'renaming another player throws');
+        _testEqual(Castles.findOne(castleId).username, 'VictimName', 'victim castle username unchanged');
+        _testEqual(Players.findOne(victimPid).username, 'VictimName', 'victim player username unchanged');
+
+        Castles.remove({gameId: game._id});
+        _testCleanup(game._id);
+        _testCleanupUser(victim._id);
+        _testCleanupUser(attacker._id);
+      });
+
+
       // --- Results ---
       console.log('\n========================================');
       console.log('  Game Creation Tests: ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
change_username loaded the player by playerId alone. The authoritative Players.update was scoped to {_id, userId:this.userId}, but the denormalized side-effect writes were not: the king-chatroom rename, the Rooms memberData update, and the Castles/Villages/Armies username updates all key on player._id. So passing a victim's playerId renamed that victim's castles/armies/villages/chatroom to an attacker-chosen string and fired a global name-change alert attributed to the victim.

Load the player scoped to {_id:playerId, userId:this.userId} up front and bail if not found, so every downstream write acts on the caller's own player only.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg