### PR TITLE
Atomically claim a battle round to prevent it running twice

### DIFF
--- a/packages/dominus-battles-ui/server/battle.js
+++ b/packages/dominus-battles-ui/server/battle.js
@@ -42,10 +42,14 @@ BattleJob.prototype.runBattle = function() {
 
   // if found a battle
   if (self.battleData) {
-    Battles2.update(self.battleData._id, {$set:{isRunning:true}});
-
-    // abort if already running
-    if (self.battleData.isRunning) {
+    // Atomically claim this battle round. The previous code set isRunning:true
+    // and then checked the STALE self.battleData.isRunning read before the
+    // update, so two concurrent runBattle jobs for the same hex (process(5) +
+    // stalled-job reprocessing) could both pass the guard and run the round,
+    // applying losses and set_lord_and_vassal/setOwner twice. Only the worker
+    // whose conditional update actually flips isRunning to true proceeds.
+    var claimed = Battles2.update({_id:self.battleData._id, isRunning:{$ne:true}}, {$set:{isRunning:true}});
+    if (!claimed) {
       return;
     }
 


### PR DESCRIPTION
The concurrency guard set isRunning:true and then tested the STALE self.battleData.isRunning value read *before* that update, so two runBattle jobs for the same hex (runBattle uses process(5), and a stalled job can be reprocessed) could both read isRunning:false and both run the round -- applying losses and set_lord_and_vassal/setOwner twice, corrupting unit counts and the feudal hierarchy.

Replace the read-then-set with a conditional update ({_id, isRunning:{$ne:true}} -> $set isRunning:true) and only proceed if it actually matched a document, so exactly one worker runs the round.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg