### PR TITLE
Guard army movement against the read-then-pop teleport race

### DIFF
--- a/packages/dominus-armies/server/moveArmiesJob2.js
+++ b/packages/dominus-armies/server/moveArmiesJob2.js
@@ -62,6 +62,20 @@ dArmies.moveArmiesJob = function(done) {
 
           var hex = path.hexes[0];
 
+          // Guard against the read-then-pop race that teleports armies. This
+          // loop iterates a cursor snapshot that can be seconds old; if an
+          // overlapping moveArmiesJob (jobs are enqueued every ~5s with no
+          // uniqueId, and a stalled job can be reprocessed) already advanced
+          // this path, popping based on the stale snapshot skips a hex and jumps
+          // the army to a non-adjacent hex. Re-read the path fresh and skip this
+          // tick unless it still matches the snapshot, so we only pop from
+          // current data. Worst case an army waits one tick -- never a teleport.
+          var freshPath = Armypaths.findOne(path._id, {fields: {hexes:1}});
+          if (!freshPath || !freshPath.hexes || freshPath.hexes.length !== path.hexes.length ||
+              freshPath.hexes[0].x !== hex.x || freshPath.hexes[0].y !== hex.y) {
+            return;
+          }
+
           let distance = path.hexes.length-1;
           var timeInMinutes = path.speed * distance;
           var time = timeInMinutes * 60 * 1000; // convert to ms


### PR DESCRIPTION
moveArmiesJob reads path.hexes[0] from a cursor snapshot and then pops the hex in a separate, non-atomic Armypaths.update. Because the job is enqueued every ~5s with no uniqueId (and a stalled job can be reprocessed), two overlapping runs can both act on the same stale snapshot, so a hex is skipped and the army jumps to a non-adjacent hex -- the intermittent "teleport" players report. The existing TODO ("hexes is sometimes null by the time we do $pop") flags this same race.

Re-read the path fresh immediately before popping and skip this tick unless the fresh hexes still match the snapshot (same length and same first hex), so the pop only ever acts on current data. Worst case an army waits one tick; it can no longer jump. This does not fully serialize the job -- a belt-and-suspenders follow-up is to give moveArmiesJob a uniqueId and make the pop a single atomic findOneAndUpdate -- but it closes the wide stale-snapshot window that produces the visible teleports.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg