### PR TITLE
Fix casualty under-count in findLoses (fails counter never reset)

### DIFF
--- a/packages/dominus-battles/calculator/armies.js
+++ b/packages/dominus-battles/calculator/armies.js
@@ -386,11 +386,16 @@ BattleArmy.prototype.findLoses = function() {
   })
 
   // take away until powerToLose is < smallestSoldierPower
-  var fails = 0;
-  var maxFails = _s.armies.types.length;
   var powerLeft = this.powerToLose;
   var numUnits = this.numUnits;
-  while (powerLeft > 0 && numUnits > 0 && fails < maxFails) {
+  while (powerLeft > 0 && numUnits > 0) {
+    // count removals this pass; stop only when a full pass removes nothing
+    // affordable. The previous code accumulated a `fails` counter across all
+    // passes, so an army holding a persistently-unaffordable expensive unit
+    // (e.g. a lone catapult) would exit early after ~types.length total fails
+    // while cheaper units it should still lose remained affordable -- an
+    // under-count of casualties.
+    var removedThisPass = 0;
     _s.armies.types.forEach(function(type) {
 
       // if there is a unit of this type in army
@@ -402,13 +407,16 @@ BattleArmy.prototype.findLoses = function() {
           loses[type]++;
           numUnits--;
           powerLeft -= self.finalPowerPerSoldier[type];
+          removedThisPass++;
 
-        } else {
-          fails++;
         }
       }
 
     })
+
+    if (removedThisPass === 0) {
+      break;
+    }
   }
 
   if (numUnits == 0) {

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -533,6 +533,39 @@ if (Meteor.isServer) {
       });
 
 
+      // --- Battle calculator: casualty count ---
+
+      run('findLoses spends all affordable power (no early exit)', function() {
+        // Regression test for fix/battle-casualty-undercount. findLoses removes
+        // soldiers worth powerToLose. The old code used a `fails` counter that
+        // accumulated across passes, so an army holding a persistently
+        // unaffordable expensive unit exited early while cheaper units it should
+        // still lose remained -- an under-count. Pure calculator test, no DB.
+        //
+        // 100 footmen at power 1 (cheap) + 1 catapult at power 100 (never
+        // affordable here). powerToLose = 20 -> exactly 20 footmen should die.
+        // Pre-fix stopped after ~types.length footmen because the catapult
+        // failed every pass; post-fix removes all 20.
+        var a = new BattleArmy();
+        a.unitType = 'army';
+        a.enemies = [];
+        a.finalPowerPerSoldier = {};
+        _s.armies.types.forEach(function(t) { a.units[t] = 0; a.finalPowerPerSoldier[t] = 0; });
+        a.units.footmen = 100;
+        a.units.catapults = 1;
+        a.finalPowerPerSoldier.footmen = 1;
+        a.finalPowerPerSoldier.catapults = 100;
+        a.numUnits = 101;
+        a.powerToLose = 20;
+
+        a.findLoses();
+
+        _testEqual(a.loses.footmen, 20, 'all 20 affordable footmen are lost');
+        _testEqual(a.loses.catapults, 0, 'unaffordable catapult is not lost');
+        _testAssert(a.destroyed === false, 'army with survivors is not destroyed');
+      });
+
+
       // --- Results ---
       console.log('\n========================================');
       console.log('  Game Creation Tests: ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
findLoses removes soldiers worth powerToLose one unit at a time. The loop guard used a `fails` counter that was declared once before the loop and accumulated across every pass: each pass, every unit type present but currently too expensive incremented `fails`, so after ~types.length total fails the loop exited via `fails < maxFails` even though cheaper units were still affordable and still owed losses. An army containing a persistently unaffordable expensive unit (e.g. a lone catapult) therefore kept units it should have lost -- a deterministic, composition-dependent under-count.

Replace the accumulating counter with per-pass progress tracking: keep removing while at least one affordable unit is removed in a pass, and stop only when a full pass removes nothing. This matches the comment ("take away until powerToLose is < smallestSoldierPower") and cannot loop forever.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg