### PR TITLE
Reset isStarting if game start fails, so the rotation can't freeze

### DIFF
--- a/packages/dominus-manager/server/gameStartJob.js
+++ b/packages/dominus-manager/server/gameStartJob.js
@@ -18,7 +18,20 @@ if (process.env.DOMINUS_WORKER == 'true') {
 
     if (game) {
       Games.update(game._id, {$set: {isStarting:true}});
-      dManager.startGame(game);
+      try {
+        dManager.startGame(game);
+      } catch (e) {
+        // startGame only sets hasStarted:true at the very end, and nothing
+        // else ever resets isStarting. If it throws partway (a createPlayer /
+        // market / tree failure), the game is left hasStarted:false,
+        // isStarting:true forever: the picker query skips isStarting:true, and
+        // createNextGame won't create a replacement while a hasStarted:false
+        // game exists -- so the whole auto-game rotation halts. Reset
+        // isStarting so the job can retry.
+        console.error('startGame failed, resetting isStarting', game._id, e);
+        Games.update(game._id, {$set: {isStarting:false}});
+        throw e;
+      }
     }
     return Promise.resolve();
   }));


### PR DESCRIPTION
checkForGameStart sets isStarting:true then calls startGame, which only sets hasStarted:true at the very end. Nothing ever resets isStarting. If startGame throws before finishing (a createPlayer/market/tree failure), the game is stuck hasStarted:false, isStarting:true forever: the picker query excludes isStarting:true so it never retries, and createNextGame refuses to create a replacement while any hasStarted:false game exists -- halting the entire auto-create-next-game rotation.

Wrap startGame in try/catch that resets isStarting:false and rethrows, so the job retries and the rotation keeps moving.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg