### PR TITLE
Fix income/vassal rank ties when the value is 0

### DIFF
--- a/packages/dominus-graphs/server/dailyStats.js
+++ b/packages/dominus-graphs/server/dailyStats.js
@@ -160,6 +160,16 @@ dGraphs.updateIncomeRank = function(gameId) {
 	Players.find({gameId:gameId}, {sort: {income:-1}, fields: {userId:1, income:1}}).forEach(function(player) {
 
 		check(player.userId, String);
+
+		// dense ranking: tied values share a rank; rank increases by 1 on each
+		// new (lower) value. Compare with !== null, not truthiness -- a previous
+		// value of 0 (the common case: most players have 0 income) was treated as
+		// "no previous", which inflated the rank of every 0 player and never
+		// collapsed a tie with the top player.
+		if (prevIncome !== null && prevIncome != player.income) {
+			rank++
+		}
+
 		Dailystats.upsert({
 			playerId: player._id,
 			created_at: {$gte: _gs.statsBegin(gameId), $lt: _gs.statsEnd(gameId)}
@@ -167,14 +177,6 @@ dGraphs.updateIncomeRank = function(gameId) {
 			$setOnInsert: {gameId:gameId, playerId:player._id, user_id:player.userId, created_at: new Date()},
 			$set: {incomeRank:rank, updated_at:new Date()}
 		});
-
-		if (prevIncome) {
-			if (prevIncome != player.income) {
-				rank++
-			}
-		} else {
-			rank++
-		}
 
 		prevIncome = player.income;
 	})
@@ -202,6 +204,16 @@ dGraphs.updateVassalRank = function(gameId) {
 	Players.find({gameId:gameId}, {sort:playerSort, fields:playerFields}).forEach(function(player) {
 
 		check(player.userId, String);
+
+		// dense ranking: tied values share a rank; rank increases by 1 on each
+		// new (lower) value. Compare with !== null, not truthiness -- a previous
+		// value of 0 (the common case: most players have no vassals) was treated
+		// as "no previous", which inflated the rank of every 0 player and never
+		// collapsed a tie with the top player.
+		if (prevNumVassals !== null && prevNumVassals != player.num_allies_below) {
+			rank++;
+		}
+
 		Dailystats.upsert({
 			playerId: player._id,
 			created_at: {$gte: _gs.statsBegin(gameId), $lt: _gs.statsEnd(gameId)}
@@ -209,14 +221,6 @@ dGraphs.updateVassalRank = function(gameId) {
 			$setOnInsert: {gameId:gameId, playerId:player._id, user_id:player.userId, created_at: new Date()},
 			$set: {vassalRank:rank, updated_at:new Date()}
 		});
-
-		if (prevNumVassals) {
-			if (prevNumVassals != player.num_allies_below) {
-				rank++;
-			}
-		} else {
-			rank++;
-		}
 
 		prevNumVassals = player.num_allies_below;
 	})

--- a/server/gameCreationTests.js
+++ b/server/gameCreationTests.js
@@ -533,6 +533,41 @@ if (Meteor.isServer) {
       });
 
 
+      // --- Rankings: tie collapse including zero ---
+
+      run('vassal/income ranks collapse ties including zero values', function() {
+        // Regression test for fix/rankings-tie-zero. The dense ranking used
+        // `if (prevNumVassals)` / `if (prevIncome)`, so a previous value of 0
+        // (the common case) was treated as "no previous" and inflated ranks.
+        // [5,5,0,0,0] used to rank 1,2,2,3,4 instead of 1,1,2,2,2.
+        Games.remove({}); Players.remove({}); Dailystats.remove({});
+        let game = _createTestGame({hasStarted: true, startedAt: new Date()});
+        let mk = function(n) {
+          return Players.insert({gameId: game._id, userId: 'u_' + Random.id(5), username: 'p_' + Random.id(3),
+            num_allies_below: n, income: n, is_king: false, king: null, lord: null, vassals: [],
+            allies_above: [], allies_below: [], team: [], castle_id: 'c_' + Random.id(3)});
+        };
+        let a = mk(5), b = mk(5), c = mk(0), d = mk(0), e = mk(0);
+
+        dGraphs.updateVassalRank(game._id);
+        let vrank = function(pid) { let ds = Dailystats.findOne({playerId: pid}); return ds ? ds.vassalRank : null; };
+        _testEqual(vrank(a), 1, 'top vassal count is rank 1');
+        _testEqual(vrank(b), 1, 'tie with top is also rank 1');
+        _testEqual(vrank(c), 2, 'zero-vassal is rank 2');
+        _testEqual(vrank(d), 2, 'zero-vassal tie is rank 2');
+        _testEqual(vrank(e), 2, 'zero-vassal tie is rank 2');
+
+        dGraphs.updateIncomeRank(game._id);
+        let irank = function(pid) { let ds = Dailystats.findOne({playerId: pid}); return ds ? ds.incomeRank : null; };
+        _testEqual(irank(a), 1, 'top income is rank 1');
+        _testEqual(irank(b), 1, 'income tie with top is rank 1');
+        _testEqual(irank(c), 2, 'zero income is rank 2');
+
+        Dailystats.remove({gameId: game._id});
+        _testCleanup(game._id);
+      });
+
+
       // --- Results ---
       console.log('\n========================================');
       console.log('  Game Creation Tests: ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
updateIncomeRank and updateVassalRank build a dense ranking but gated the tie check on `if (prevIncome)` / `if (prevNumVassals)`. Because 0 is falsy, any time the previous player's value was 0 the code took the else branch and incremented rank unconditionally -- so ties among the (majority) 0 players were never collapsed, and because prev starts null a tie with the top player was never collapsed either. [5,5,0,0,0] ranked as 1,2,2,3,4 instead of 1,1,2,2,2.

These ranks are copied into player.rankByIncome / rankByVassals at game end and shown on profiles and rank graphs. Compare prev with !== null and move the increment before the upsert so tied values share a rank.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg