### PR TITLE
Actually trim player docs on game close

### DIFF
--- a/packages/dominus-manager/server/gameCloseJob.js
+++ b/packages/dominus-manager/server/gameCloseJob.js
@@ -47,9 +47,17 @@ var cleanupPlayers = function(gameId) {
 	var hasBulkOp = false;
 
   Players.find({gameId:gameId}, {fields:keep}).forEach(function(player) {
-    // player.gameIsClosed = true;
-    // bulk.find({_id:player._id}).updateOne(player);
-    bulk.find({_id:player._id}).updateOne({$set:{gameIsClosed:true}});
+    // Replace the doc with only the whitelisted fields (the game is being
+    // erased), mirroring cleanupGame below. Previously this only did
+    // $set gameIsClosed:true, so the `keep` whitelist was dead code and closed-
+    // game player docs kept every field forever -- unbounded bloat plus stale
+    // is_dominus:true / is_king left on dead games. player was fetched with
+    // {fields:keep} so it already holds just the kept fields; drop _id (it is
+    // immutable and used as the filter) and mark it closed.
+    var id = player._id;
+    delete player._id;
+    player.gameIsClosed = true;
+    bulk.find({_id:id}).replaceOne(player);
     hasBulkOp = true;
   });
 


### PR DESCRIPTION
cleanupPlayers built a `keep` field whitelist and read players with it, but the bulk op only did $set:{gameIsClosed:true} -- the whitelist was dead code (the doc-replacement was commented out). So closed-game player documents retained every field forever: unbounded data bloat, plus stale is_dominus / is_king / castle / army state left on finished games.

Replace each player doc with just the whitelisted fields (mirroring cleanupGame, which already does this for the game doc). The doc is fetched with {fields:keep}, so drop its _id (immutable, used as the filter), mark it gameIsClosed, and replaceOne.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg