### PR TITLE
Fix misplaced parenthesis in createArmyFromBuilding soldier guard

### DIFF
--- a/packages/dominus-armies/both/armyMethods.js
+++ b/packages/dominus-armies/both/armyMethods.js
@@ -230,7 +230,7 @@ Meteor.methods({
     var hasSoldiers = false;
     var buildingHasEnough = true;
     _s.armies.types.forEach(function(type) {
-      if (typeof(soldiers[type] != "undefined")) {
+      if (typeof soldiers[type] != "undefined") {
 
         check(soldiers[type], Match.Integer);
 


### PR DESCRIPTION
The guard read `if (typeof(soldiers[type] != "undefined"))`, i.e. typeof(<boolean>), which is always the string "boolean" (truthy), so the guard never actually skipped missing unit types. When a client omitted a type, check(soldiers[type], Match.Integer) then ran on undefined and threw.

Intended: `if (typeof soldiers[type] != "undefined")`.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg