### PR TITLE
Fix Random.id and future.wait bugs in updateVassalAllyCountMultiple

### DIFF
--- a/packages/dominus-init/server/relationships.js
+++ b/packages/dominus-init/server/relationships.js
@@ -368,7 +368,7 @@ var updateVassalAllyCountMultiple = function(playerIds) {
 
 		var dsFind = {playerId: player._id, created_at: {$gte: _gs.statsBegin(player.gameId), $lt: _gs.statsEnd(player.gameId)}};
     var dsSet = {numVassals:num_allies_below, updated_at:new Date()};
-    var dsSetOnInsert = {_id:Random.id, gameId:player.gameId, user_id:player.userId, playerId:player._id, created_at: new Date()};
+    var dsSetOnInsert = {_id:Random.id(), gameId:player.gameId, user_id:player.userId, playerId:player._id, created_at: new Date()};
     bulkDailystats.find(dsFind).upsert().updateOne({$set:dsSet, $setOnInsert:dsSetOnInsert});
 
 		hasBulkOp = true;
@@ -389,7 +389,7 @@ var updateVassalAllyCountMultiple = function(playerIds) {
 	    }
 	    futureDailystats.return(result);
 	  });
-	  futurePlayers.wait();
+	  futureDailystats.wait();
 	}
 
 };


### PR DESCRIPTION
Two bugs in the dailystats upsert:
- $setOnInsert used `_id:Random.id` (the function reference) instead of `Random.id()`, so on insert the dailystats _id was set to a function rather than a generated id.
- After executing the dailystats bulk op it called `futurePlayers.wait()` again (already resolved) instead of `futureDailystats.wait()`, so the dailystats write was never actually awaited.


Claude-Session: https://claude.ai/code/session_01SYfL395ov7UF8LccYiuvXg