### PR TITLE
Reduce map pan lag (Session thrash on drag)

### DIFF
--- a/game/miscTemplates/client/hover_box.js
+++ b/game/miscTemplates/client/hover_box.js
@@ -27,7 +27,8 @@ Template.hover_box.helpers({
 		// this is outside of #hexes so it needs to be scaled
 		var x = grid.x * Session.get('hexScale')
 
-		return Session.get('hexes_pos').x + x + offset
+		var hexesPos = (typeof dHexmap !== 'undefined' && dHexmap.getCurrentHexPos) ? dHexmap.getCurrentHexPos() : Session.get('hexes_pos');
+		return hexesPos.x + x + offset
 	},
 
 	top: function() {
@@ -54,7 +55,8 @@ Template.hover_box.helpers({
 		// this is outside of #hexes so it needs to be scaled
 		var y = grid.y * Session.get('hexScale')
 
-		return Session.get('hexes_pos').y + y + offset
+		var hexesPos = (typeof dHexmap !== 'undefined' && dHexmap.getCurrentHexPos) ? dHexmap.getCurrentHexPos() : Session.get('hexes_pos');
+		return hexesPos.y + y + offset
 	},
 
 	objects: function() {

--- a/game/miscTemplates/client/hover_box.js
+++ b/game/miscTemplates/client/hover_box.js
@@ -27,7 +27,10 @@ Template.hover_box.helpers({
 		// this is outside of #hexes so it needs to be scaled
 		var x = grid.x * Session.get('hexScale')
 
-		var hexesPos = (typeof dHexmap !== 'undefined' && dHexmap.getCurrentHexPos) ? dHexmap.getCurrentHexPos() : Session.get('hexes_pos');
+		// Read Session unconditionally so this helper stays reactive on pan
+		// commits; getCurrentHexPos itself never registers the dependency.
+		var sessionPos = Session.get('hexes_pos');
+		var hexesPos = (typeof dHexmap !== 'undefined' && dHexmap.getCurrentHexPos) ? dHexmap.getCurrentHexPos() : sessionPos;
 		return hexesPos.x + x + offset
 	},
 
@@ -55,7 +58,10 @@ Template.hover_box.helpers({
 		// this is outside of #hexes so it needs to be scaled
 		var y = grid.y * Session.get('hexScale')
 
-		var hexesPos = (typeof dHexmap !== 'undefined' && dHexmap.getCurrentHexPos) ? dHexmap.getCurrentHexPos() : Session.get('hexes_pos');
+		// Read Session unconditionally so this helper stays reactive on pan
+		// commits; getCurrentHexPos itself never registers the dependency.
+		var sessionPos = Session.get('hexes_pos');
+		var hexesPos = (typeof dHexmap !== 'undefined' && dHexmap.getCurrentHexPos) ? dHexmap.getCurrentHexPos() : sessionPos;
 		return hexesPos.y + y + offset
 	},
 

--- a/packages/dominus-hexmap/client/hexmap.js
+++ b/packages/dominus-hexmap/client/hexmap.js
@@ -82,6 +82,7 @@ Template.hexmap.onDestroyed(function() {
       expireIn:10
     });
   }
+  dHexmap.clearHexesElCache();
 });
 
 Template.hexmap.onCreated(function() {
@@ -273,6 +274,7 @@ let setCenterHex = _.debounce(function(hexes_pos) {
 Template.hexmap.destroyed = function() {
 	dHexmap.mapmover.stop();
   removeHexHighlights();
+  dHexmap.clearHexesElCache();
 }
 
 

--- a/packages/dominus-hexmap/client/hexmapClientFunctions.js
+++ b/packages/dominus-hexmap/client/hexmapClientFunctions.js
@@ -1,35 +1,82 @@
-// offset your position on the map
-// this is pixel position not coordinates
-dHexmap.offsetHexes = function(offsetX, offsetY) {
-  check(offsetX, validNumber);
-  check(offsetY, validNumber);
-  var hexPos = Session.get('hexes_pos');
-  if (hexPos) {
-    x = hexPos.x + offsetX;
-		y = hexPos.y + offsetY;
-		dHexmap.moveHexesTo(x, y);
+// Cached DOM node for the SVG map layer (avoid jQuery lookup every pan frame).
+var hexesEl = null;
+
+var getHexesEl = function() {
+  if (!hexesEl) {
+    hexesEl = document.getElementById('hexes');
   }
+  return hexesEl;
 };
 
-// TODO: https://davidwalsh.name/translate3d
-// move the map to a position
-// this is pixel position not coordinates
-dHexmap.moveHexesTo = function(pixelX, pixelY) {
-  check(pixelX, validNumber);
-	check(pixelY, validNumber);
+var getCurrentHexPos = function() {
+  // Prefer live mapPos (updated every visual pan frame). Session may lag during drag.
+  if (typeof mapPos !== 'undefined' && mapPos && typeof mapPos.x === 'number') {
+    return mapPos;
+  }
+  return Session.get('hexes_pos');
+};
+
+// Visual pan only: update canvas mapPos + SVG CSS transform. No Session.set.
+// Used on the drag hot path so Meteor/Blaze are not invalidated every mousemove.
+dHexmap.moveHexesToVisual = function(pixelX, pixelY) {
   var hexScale = Session.get('hexScale');
   if (!hexScale) {
     hexScale = 1;
   }
 
-  // for map, instead of using session
-  mapPos = {x:pixelX, y:pixelY};
-
   pixelX = parseFloat(pixelX);
   pixelY = parseFloat(pixelY);
-  //$('#hexes').attr('transform', 'translate('+pixelX+','+pixelY+') scale('+hexScale+')')
-  $('#hexes').attr('style', 'transform:translate3d('+pixelX+'px,'+pixelY+'px, 0px) scale3d('+hexScale+', '+hexScale+', 1)')
-  Session.set('hexes_pos', {x:pixelX, y:pixelY})
+
+  mapPos = {x: pixelX, y: pixelY};
+
+  var el = getHexesEl();
+  if (el) {
+    el.style.transform =
+      'translate3d(' + pixelX + 'px,' + pixelY + 'px, 0px) scale3d(' +
+      hexScale + ', ' + hexScale + ', 1)';
+  }
+};
+
+// Commit map position to Session (subscriptions, hover box, center_hex tracking).
+dHexmap.commitHexesPos = function() {
+  if (typeof mapPos === 'undefined' || !mapPos) {
+    return;
+  }
+  var cur = Session.get('hexes_pos');
+  if (cur && cur.x === mapPos.x && cur.y === mapPos.y) {
+    return;
+  }
+  Session.set('hexes_pos', {x: mapPos.x, y: mapPos.y});
+};
+
+// offset your position on the map
+// this is pixel position not coordinates
+// Full commit — used by non-drag callers if any.
+dHexmap.offsetHexes = function(offsetX, offsetY) {
+  check(offsetX, validNumber);
+  check(offsetY, validNumber);
+  var hexPos = getCurrentHexPos();
+  if (hexPos) {
+    dHexmap.moveHexesTo(hexPos.x + offsetX, hexPos.y + offsetY);
+  }
+};
+
+// Visual offset only (drag hot path). No Session.set.
+dHexmap.offsetHexesVisual = function(offsetX, offsetY) {
+  var hexPos = getCurrentHexPos();
+  if (hexPos) {
+    dHexmap.moveHexesToVisual(hexPos.x + offsetX, hexPos.y + offsetY);
+  }
+};
+
+// move the map to a position (visual + Session commit)
+// this is pixel position not coordinates
+// Used by centerOnHex, nav panel, etc.
+dHexmap.moveHexesTo = function(pixelX, pixelY) {
+  check(pixelX, validNumber);
+  check(pixelY, validNumber);
+  dHexmap.moveHexesToVisual(pixelX, pixelY);
+  dHexmap.commitHexesPos();
 };
 
 // center the map on a hex
@@ -37,54 +84,60 @@ dHexmap.moveHexesTo = function(pixelX, pixelY) {
 // why * -1 ?????
 dHexmap.centerOnHex = function(x, y) {
   check(x, Match.Integer);
-	check(y, Match.Integer);
+  check(y, Match.Integer);
 
   var hexScale = Session.get('hexScale')
-	var canvasSize = Session.get('canvas_size');
+  var canvasSize = Session.get('canvas_size');
 
   if (!hexScale) {
     hexScale = 1;
   }
 
-	if (canvasSize && hexScale) {
+  if (canvasSize && hexScale) {
     var grid = Hx.coordinatesToPos(x, y, _s.init.hexSize, _s.init.hexSquish)
 
-		var x = canvasSize.width/2
-		var y = canvasSize.height/2
+    var x = canvasSize.width/2
+    var y = canvasSize.height/2
 
-		x += grid.x * hexScale * -1
-		y += grid.y * hexScale * -1
+    x += grid.x * hexScale * -1
+    y += grid.y * hexScale * -1
 
-		dHexmap.moveHexesTo(x, y)
+    dHexmap.moveHexesTo(x, y)
   }
 };
 
 dHexmap.setHexScale = function(scale) {
   check(scale, validNumber);
   Session.set('hexScale', scale);
+  // Re-apply transform at current pos so scale change updates SVG immediately.
+  var hexPos = getCurrentHexPos();
+  if (hexPos) {
+    dHexmap.moveHexesToVisual(hexPos.x, hexPos.y);
+  }
   _saveHexScale();
 };
 
 dHexmap.getCoordinatesFromEvent = function(event) {
   // get click position
-	// if is a touch event
-	if (_.contains(['touchstart', 'touchend', 'touchcancel', 'touchmove'], event.type)) {
-		var x = event.originalEvent.touches[0].pageX
-		var y = event.originalEvent.touches[0].pageY
-	} else {
-		var x = event.clientX || event.pageX
-		var y = event.clientY || event.pageY
-	}
+  // if is a touch event
+  if (_.contains(['touchstart', 'touchend', 'touchcancel', 'touchmove'], event.type)) {
+    var x = event.originalEvent.touches[0].pageX
+    var y = event.originalEvent.touches[0].pageY
+  } else {
+    var x = event.clientX || event.pageX
+    var y = event.clientY || event.pageY
+  }
 
-	var hexesPos = Session.get('hexes_pos')
-	var hexScale = s.hex_size * Session.get('hexScale')
+  // Use live map position so pathfinding stays accurate during pan.
+  var hexesPos = getCurrentHexPos()
+  var hexScale = s.hex_size * Session.get('hexScale')
 
-	if (hexesPos && hexScale) {
-		// get hex coordinates
-		var coord = Hx.posToCoordinates(x-hexesPos.x, y-hexesPos.y, hexScale, s.hex_squish)
+  if (hexesPos && hexScale) {
+    // get hex coordinates
+    var coord = Hx.posToCoordinates(x-hexesPos.x, y-hexesPos.y, hexScale, s.hex_squish)
 
-		return coord
-	}
+    return coord
+  }
 }
 
 

--- a/packages/dominus-hexmap/client/hexmapClientFunctions.js
+++ b/packages/dominus-hexmap/client/hexmapClientFunctions.js
@@ -2,15 +2,24 @@
 var hexesEl = null;
 
 var getHexesEl = function() {
+  // Invalidate if the map template was destroyed/recreated (detached node).
+  if (hexesEl && !(document.body && document.body.contains(hexesEl))) {
+    hexesEl = null;
+  }
   if (!hexesEl) {
     hexesEl = document.getElementById('hexes');
   }
   return hexesEl;
 };
 
-var getCurrentHexPos = function() {
-  // Prefer live mapPos (updated every visual pan frame). Session may lag during drag.
-  if (typeof mapPos !== 'undefined' && mapPos && typeof mapPos.x === 'number') {
+// Call when Template.hexmap is destroyed so the next enter re-queries #hexes.
+dHexmap.clearHexesElCache = function() {
+  hexesEl = null;
+};
+
+// Prefer live mapPos (updated every visual pan frame). Session may lag during drag.
+dHexmap.getCurrentHexPos = function() {
+  if (typeof mapPos !== 'undefined' && mapPos && typeof mapPos.x === 'number' && isFinite(mapPos.x)) {
     return mapPos;
   }
   return Session.get('hexes_pos');
@@ -19,13 +28,17 @@ var getCurrentHexPos = function() {
 // Visual pan only: update canvas mapPos + SVG CSS transform. No Session.set.
 // Used on the drag hot path so Meteor/Blaze are not invalidated every mousemove.
 dHexmap.moveHexesToVisual = function(pixelX, pixelY) {
+  pixelX = parseFloat(pixelX);
+  pixelY = parseFloat(pixelY);
+  // Keep hot path cheap but avoid silent NaN blanking the map.
+  if (!isFinite(pixelX) || !isFinite(pixelY)) {
+    return;
+  }
+
   var hexScale = Session.get('hexScale');
   if (!hexScale) {
     hexScale = 1;
   }
-
-  pixelX = parseFloat(pixelX);
-  pixelY = parseFloat(pixelY);
 
   mapPos = {x: pixelX, y: pixelY};
 
@@ -42,6 +55,9 @@ dHexmap.commitHexesPos = function() {
   if (typeof mapPos === 'undefined' || !mapPos) {
     return;
   }
+  if (!isFinite(mapPos.x) || !isFinite(mapPos.y)) {
+    return;
+  }
   var cur = Session.get('hexes_pos');
   if (cur && cur.x === mapPos.x && cur.y === mapPos.y) {
     return;
@@ -49,21 +65,14 @@ dHexmap.commitHexesPos = function() {
   Session.set('hexes_pos', {x: mapPos.x, y: mapPos.y});
 };
 
-// offset your position on the map
-// this is pixel position not coordinates
-// Full commit — used by non-drag callers if any.
-dHexmap.offsetHexes = function(offsetX, offsetY) {
-  check(offsetX, validNumber);
-  check(offsetY, validNumber);
-  var hexPos = getCurrentHexPos();
-  if (hexPos) {
-    dHexmap.moveHexesTo(hexPos.x + offsetX, hexPos.y + offsetY);
-  }
-};
-
 // Visual offset only (drag hot path). No Session.set.
 dHexmap.offsetHexesVisual = function(offsetX, offsetY) {
-  var hexPos = getCurrentHexPos();
+  offsetX = parseFloat(offsetX);
+  offsetY = parseFloat(offsetY);
+  if (!isFinite(offsetX) || !isFinite(offsetY)) {
+    return;
+  }
+  var hexPos = dHexmap.getCurrentHexPos();
   if (hexPos) {
     dHexmap.moveHexesToVisual(hexPos.x + offsetX, hexPos.y + offsetY);
   }
@@ -110,7 +119,7 @@ dHexmap.setHexScale = function(scale) {
   check(scale, validNumber);
   Session.set('hexScale', scale);
   // Re-apply transform at current pos so scale change updates SVG immediately.
-  var hexPos = getCurrentHexPos();
+  var hexPos = dHexmap.getCurrentHexPos();
   if (hexPos) {
     dHexmap.moveHexesToVisual(hexPos.x, hexPos.y);
   }
@@ -129,7 +138,7 @@ dHexmap.getCoordinatesFromEvent = function(event) {
   }
 
   // Use live map position so pathfinding stays accurate during pan.
-  var hexesPos = getCurrentHexPos()
+  var hexesPos = dHexmap.getCurrentHexPos()
   var hexScale = s.hex_size * Session.get('hexScale')
 
   if (hexesPos && hexScale) {

--- a/packages/dominus-hexmap/client/mapmover.js
+++ b/packages/dominus-hexmap/client/mapmover.js
@@ -1,20 +1,38 @@
-var lastPos = {x:null,y:null}
+var lastPos = {x: null, y: null};
+var lastScale = null;
 
-dHexmap.mapmover = new Mapmover(function(x,y,scale) {
-	// beginning of move
-	beginPos = {x:x,y:y}
+// During long drags, occasionally commit Session so country loading / center_hex
+// still track the view (center_hex itself is already debounced 500ms).
+// Drag end always does a hard commit.
+var commitHexesPosThrottled = _.throttle(function() {
+  dHexmap.commitHexesPos();
+}, 400);
 
-}, function(x,y,scale) {
-	// during move
-	dHexmap.offsetHexes(x-lastPos.x, y-lastPos.y)
-	dHexmap.setHexScale(scale)
-	lastPos = {x:x, y:y}
+dHexmap.mapmover = new Mapmover(function(x, y, scale) {
+  // beginning of move — sync last* so the first delta is 0
+  lastPos = {x: x, y: y};
+  lastScale = scale;
 
-}, function(x,y,scale) {
-	// end of move
-	dHexmap.offsetHexes(x-lastPos.x, y-lastPos.y)
-	dHexmap.setHexScale(scale)
-})
+}, function(x, y, scale) {
+  // during move — visual pan only; avoid Session.set every frame
+  dHexmap.offsetHexesVisual(x - lastPos.x, y - lastPos.y);
+  if (scale !== lastScale) {
+    dHexmap.setHexScale(scale);
+    lastScale = scale;
+  }
+  lastPos = {x: x, y: y};
+  commitHexesPosThrottled();
+
+}, function(x, y, scale) {
+  // end of move — final visual offset + commit Session once
+  dHexmap.offsetHexesVisual(x - lastPos.x, y - lastPos.y);
+  if (scale !== lastScale) {
+    dHexmap.setHexScale(scale);
+    lastScale = scale;
+  }
+  lastPos = {x: x, y: y};
+  dHexmap.commitHexesPos();
+});
 
 dHexmap.mapmover.throttle = 33;
 dHexmap.mapmover.minScale = _s.init.hexScaleMin;


### PR DESCRIPTION
## Summary

Low-risk performance fix for laggy click+drag map panning.

- During drag: update `mapPos` + `#hexes` CSS transform every frame (same visuals as today)
- Do **not** call `Session.set('hexes_pos')` on every mousemove
- Commit Session on drag end, and throttled (~400ms) during long drags so country loading still tracks the view
- Call `setHexScale` only when scale actually changed
- Cache the `#hexes` DOM node; skip `check()` on the visual pan hot path

Canvas still fully redraws every frame via `mapPos` (no frozen-frame / blank-edge tricks). This only removes reactive thrash.

## Test plan

- [ ] Drag map quickly — terrain and SVG flags/armies stay aligned; no blank edges
- [ ] Long drag into unloaded area — countries still load during/after pan
- [ ] Click without drag still selects hexes/buildings
- [ ] Zoom (ctrl+shift wheel / pinch) still works
- [ ] Nav panel arrows still move the map
- [ ] Hover box still works after pan settles