### PR TITLE
Replace dead Simple Analytics embed with self-hosted Bearlytics

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -23,12 +23,5 @@
 </head>
 <body>
 	{{> Template.dynamic template=route}}
-	<script
-		data-ignore-pages="/game/*"
-		data-collect-dnt="true"
-		async
-		defer
-		src="https://simple.ennogames.com/latest.js"
-	></script>
-	<noscript><img src="https://simple.ennogames.com/noscript.gif?collect-dnt=true" alt="" referrerpolicy="no-referrer-when-downgrade" /></noscript>
+	<script data-site="ODVORAG" src="https://stats.danp.us/script.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary

- Adds the Bearlytics tracker: `<script data-site="ODVORAG" src="https://stats.danp.us/script.js" defer></script>`
- Removes the Simple Analytics embed (`simple.ennogames.com/latest.js`) and its noscript pixel, which fail on every page load with `ERR_CERT_COMMON_NAME_INVALID`

## Why the error happens

`simple.ennogames.com` is a CNAME to Simple Analytics'' custom-domain endpoint (`simpleanalyticsexternal.com`). That endpoint now serves a TLS certificate valid only for `external.simpleanalytics.com` — the custom-domain cert for `simple.ennogames.com` is no longer being provisioned (typical when the custom-domain registration/subscription lapses). The browser rejects the mismatched cert, so the analytics script has not been loading at all. Since analytics is moving to self-hosted Bearlytics anyway, the fix is removal rather than repairing the Simple Analytics domain.

Note: the old embed had `data-ignore-pages="/game/*"` (in-game pages untracked). Bearlytics tracks all pages; if in-game pageviews should stay excluded, that needs a Bearlytics-side setting or a follow-up.

## Test plan

- [ ] Load the site with dev tools open — no `ERR_CERT_COMMON_NAME_INVALID` in console
- [ ] `stats.danp.us/script.js` loads and a pageview appears in the Bearlytics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)