### PR TITLE
Remove stale footer links

### DIFF
--- a/packages/dominus-landing/client/landingFooter.html
+++ b/packages/dominus-landing/client/landingFooter.html
@@ -56,9 +56,6 @@
 
           <a href="https://store.steampowered.com/app/1347540?utm_source=dominus" target="_blank">Sky Fleet</a> - In Development by Dan<br>
           <a href="http://astroe.io" target="_blank">Astroe</a> - Multiplayer 2D space battle.<br>
-          <a href="https://gamedevjobs.io" target="_blank">Game Developer Jobs</a> - Get a job in games.<br>
-          <a href="https://dotsgame.co" target="_blank">Dots and Boxes</a> - Play the classic pen and paper game online.<br>
-          <a href="http://io-games.zone" target="_blank">More IO Games</a> - All the best .io games in one list.<br>
 
           <br><br>
           <a href="/privacy">Privacy Policy</a>


### PR DESCRIPTION
## Summary

Removes three links from the landing page footer: Game Developer Jobs (gamedevjobs.io), Dots and Boxes (dotsgame.co), and More IO Games (io-games.zone). Sky Fleet and Astroe remain.

## Test plan

- [ ] Landing page footer shows only Sky Fleet and Astroe under the social icons, followed by Privacy Policy / Terms of Service

🤖 Generated with [Claude Code](https://claude.com/claude-code)