### PR TITLE
Fix map drag smoothness and mid-drag tracking (follow-ups to #54)

### DIFF
--- a/game/miscTemplates/client/hover_box.js
+++ b/game/miscTemplates/client/hover_box.js
@@ -1,5 +1,10 @@
 Template.hover_box.helpers({
 	draw: function() {
+		// Hide while panning: position only syncs on Session commits (~400ms
+		// during a drag), so mid-drag the box floats visibly out of place.
+		if (typeof dHexmap !== 'undefined' && dHexmap.mapmover && dHexmap.mapmover.isDraggingOrScalingReactive.get()) {
+			return false;
+		}
 		return (Session.get('hover_on_object') || Session.get('hover_on_hover_box'));
 	},
 

--- a/packages/dominus-hexmap/client/hexmap.js
+++ b/packages/dominus-hexmap/client/hexmap.js
@@ -258,7 +258,10 @@ Template.hexmap.onRendered(function() {
 });
 
 
-let setCenterHex = _.debounce(function(hexes_pos) {
+// Throttle, not debounce: a debounce is starved by the ~400ms commits during a
+// drag and never fired until the drag ended, freezing the minimap camera border
+// and deferring country loading. Throttle fires during sustained drags too.
+let setCenterHex = _.throttle(function(hexes_pos) {
   let pixel = dHexmap.grid_to_pixel(hexes_pos.x, hexes_pos.y)
   if (pixel) {
     let coords = Hx.posToCoordinates(pixel.x, pixel.y, s.hex_size, s.hex_squish)

--- a/packages/dominus-hexmap/client/mapmover.js
+++ b/packages/dominus-hexmap/client/mapmover.js
@@ -2,7 +2,7 @@ var lastPos = {x: null, y: null};
 var lastScale = null;
 
 // During long drags, occasionally commit Session so country loading / center_hex
-// still track the view (center_hex itself is already debounced 500ms).
+// still track the view (center_hex itself is throttled to 500ms).
 // Drag end always does a hard commit.
 var commitHexesPosThrottled = _.throttle(function() {
   dHexmap.commitHexesPos();
@@ -34,6 +34,15 @@ dHexmap.mapmover = new Mapmover(function(x, y, scale) {
   dHexmap.commitHexesPos();
 });
 
-dHexmap.mapmover.throttle = 33;
+// Assigning .throttle after construction is a no-op: the Mapmover constructor
+// already created _changed with _.throttle(fn, 100), so drags updated at 10fps
+// — the map moved in visible steps. Rebuild the throttled callback at ~60fps;
+// the visual-only hot path above is cheap enough for that now.
+dHexmap.mapmover.throttle = 16;
+dHexmap.mapmover._changed = _.throttle(function() {
+  var m = dHexmap.mapmover;
+  m.callback(m.moveX, m.moveY, m.scale);
+}, dHexmap.mapmover.throttle);
+
 dHexmap.mapmover.minScale = _s.init.hexScaleMin;
 dHexmap.mapmover.maxScale = _s.init.hexScaleMax;


### PR DESCRIPTION
## Summary

Three small, independent fixes on top of #54:

1. **Drag was capped at 10fps — the real cause of jumpy panning.** `dHexmap.mapmover.throttle = 33` was a no-op: the `Mapmover` constructor creates its internal `_.throttle` wrapper with the default `100` before that assignment runs, so drags have updated every 100ms for years. #54 made per-frame work cheap but could not raise this cap, which is why it showed no visible improvement. The throttled callback is now rebuilt at 16ms (~60fps).

2. **Hover box hidden during drags.** Its position syncs on Session commits (~400ms apart mid-drag), so it floated out of place while panning. It now hides during a drag (via `isDraggingOrScalingReactive`) and reappears correctly positioned on release.

3. **Minimap camera border + country loading now track during drags.** `setCenterHex` was `_.debounce(500)`, which is starved by the ~400ms commits during a drag — `center_hex` only updated after release. Switched to `_.throttle(500)` so it fires during sustained drags as well.

## Test plan

- [ ] Drag the map — movement is visibly smoother (~60fps instead of 10fps steps)
- [ ] Hover a castle/army so the popup shows, then drag — popup disappears during the drag and reappears correctly placed after release
- [ ] Long drag — minimap camera border follows every ~500ms; countries/armies load mid-drag
- [ ] Zoom (ctrl+shift wheel / pinch) still works; click-to-select still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)