### PR TITLE
Speed up minimap camera border tracking during drags

### DIFF
--- a/packages/dominus-hexmap/client/hexmap.js
+++ b/packages/dominus-hexmap/client/hexmap.js
@@ -258,9 +258,11 @@ Template.hexmap.onRendered(function() {
 });
 
 
-// Throttle, not debounce: a debounce is starved by the ~400ms commits during a
+// Throttle, not debounce: a debounce is starved by the commits during a
 // drag and never fired until the drag ended, freezing the minimap camera border
 // and deferring country loading. Throttle fires during sustained drags too.
+// 200ms paces the minimap camera border and countryIdsOnscreen; commits arrive
+// every ~150ms during a drag (see commitHexesPosThrottled in mapmover.js).
 let setCenterHex = _.throttle(function(hexes_pos) {
   let pixel = dHexmap.grid_to_pixel(hexes_pos.x, hexes_pos.y)
   if (pixel) {
@@ -270,7 +272,7 @@ let setCenterHex = _.throttle(function(hexes_pos) {
     let y = coords.y * -1
     Session.set('center_hex', {x:x, y:y})
   }
-}, 500);
+}, 200);
 
 
 

--- a/packages/dominus-hexmap/client/mapmover.js
+++ b/packages/dominus-hexmap/client/mapmover.js
@@ -2,11 +2,12 @@ var lastPos = {x: null, y: null};
 var lastScale = null;
 
 // During long drags, occasionally commit Session so country loading / center_hex
-// still track the view (center_hex itself is throttled to 500ms).
-// Drag end always does a hard commit.
+// still track the view (center_hex itself is throttled to 200ms).
+// Drag end always does a hard commit. This interval also paces the minimap
+// camera border, which reads center_hex — keep the two in the same ballpark.
 var commitHexesPosThrottled = _.throttle(function() {
   dHexmap.commitHexesPos();
-}, 400);
+}, 150);
 
 dHexmap.mapmover = new Mapmover(function(x, y, scale) {
   // beginning of move — sync last* so the first delta is 0


### PR DESCRIPTION
## Summary

The minimap camera border lagged noticeably during drags (~500-900ms between moves) because two stacked throttles pace it:

- `commitHexesPosThrottled` (mapmover.js): 400ms -> **150ms**
- `setCenterHex` (hexmap.js): 500ms -> **200ms**

The border now tracks at ~5 updates/sec during a pan. `center_hex` also drives `countryIdsOnscreen` (client-side `CountryIndex.find` + `Session.set`) and hover-box repositioning, so the intervals stay throttled rather than per-frame — still an order of magnitude less reactive work than the pre-#54 per-mousemove behavior.

## Test plan

- [ ] Drag the map — minimap camera border follows smoothly (~5 updates/sec) instead of lurching every half-second+
- [ ] Long drag into unloaded territory — countries/armies stream in during the drag
- [ ] No stutter introduced while dragging (the added work per tick is small)

🤖 Generated with [Claude Code](https://claude.com/claude-code)